### PR TITLE
`master` branch should be using `master` version number and not `8.0.0`

### DIFF
--- a/README.md
+++ b/README.md
@@ -413,5 +413,5 @@ The file `include/ballot-verifier/screen.h` includes the PNG found in
 [wxWidgets]: https://www.wxwidgets.org/
 [git]: https://github.com/sequentech/ballot-verifier/
 [GitHub]: https://github.com/sequentech/ballot-verifier/
-[Linux binary]: https://github.com/sequentech/ballot-verifier/releases/download/4.0.1/ballot-verifier-gui-linux
-[Mac OS X binary]: https://github.com/sequentech/ballot-verifier/releases/download/4.0.1/ballot-verifier-gui-mac
+[Linux binary]: https://github.com/sequentech/ballot-verifier/releases/download/8.0.1/ballot-verifier-gui-linux
+[Mac OS X binary]: https://github.com/sequentech/ballot-verifier/releases/download/8.0.1/ballot-verifier-gui-mac

--- a/README.md
+++ b/README.md
@@ -413,5 +413,5 @@ The file `include/ballot-verifier/screen.h` includes the PNG found in
 [wxWidgets]: https://www.wxwidgets.org/
 [git]: https://github.com/sequentech/ballot-verifier/
 [GitHub]: https://github.com/sequentech/ballot-verifier/
-[Linux binary]: https://github.com/sequentech/ballot-verifier/releases/download/8.0.0/ballot-verifier-gui-linux
-[Mac OS X binary]: https://github.com/sequentech/ballot-verifier/releases/download/8.0.0/ballot-verifier-gui-mac
+[Linux binary]: https://github.com/sequentech/ballot-verifier/releases/download/4.0.1/ballot-verifier-gui-linux
+[Mac OS X binary]: https://github.com/sequentech/ballot-verifier/releases/download/4.0.1/ballot-verifier-gui-mac

--- a/project.spdx.yml
+++ b/project.spdx.yml
@@ -4,7 +4,7 @@
 SPDXID: "SPDXRef-DOCUMENT"
 spdxVersion: "SPDX-2.2"
 creationInfo:
-  created: "2023-06-06T17:07:07Z"
+  created: "2021-11-26T19:20:02Z"
   creators:
   - "Organization: Sequent Tech Inc."
   - "Person: Eduardo Robles"
@@ -18,13 +18,13 @@ packages:
 - SPDXID: "SPDXRef-Package-ballot-verifier"
   summary: "Sequent cast-as-intended verifier"
   copyrightText: "Copyright 2014-2021 Sequent Tech Inc"
-  downloadLocation: "git+https://github.com/sequentech/ballot-verifier.git@8.0.0"
+  downloadLocation: "git+https://github.com/sequentech/ballot-verifier.git@master"
   filesAnalyzed: false
   homepage: "https://github.com/sequentech/ballot-verifier"
   licenseConcluded:  "NOASSERTION"
   licenseDeclared: "AGPL-3.0-only"
   name: "ballot-verifier"
-  versionInfo: "8.0.0"
+  versionInfo: "master"
 - SPDXID: "SPDXRef-Package-cmake"
   description: "Cross Platform Makefile Generator"
   copyrightText: "Copyright (c) 2000-2021 Kitware, Inc. and Contributors"


### PR DESCRIPTION
Parent issue: https://github.com/sequentech/meta/issues/136

Revert "Release for version 8.0.0"

This reverts commit 3c12694354043a62ef546e21bb55b4b9dc5f6405.